### PR TITLE
Fix copy-pasted error context messages in CarddavClient

### DIFF
--- a/src/carddav/client.rs
+++ b/src/carddav/client.rs
@@ -220,7 +220,7 @@ impl<'a> CarddavClient<'a> {
         loop {
             match create.resume(arg.take()) {
                 SendResult::Ok(_) => break Ok(()),
-                SendResult::Err(err) => return Err(anyhow!(err).context("Creat addressbook error")),
+                SendResult::Err(err) => return Err(anyhow!(err).context("Create addressbook error")),
                 SendResult::Io(io) => arg = Some(handle(&mut self.stream, io)?),
             }
         }
@@ -277,7 +277,7 @@ impl<'a> CarddavClient<'a> {
             match create.resume(arg.take()) {
                 SendResult::Ok(_) => break Ok(()),
                 SendResult::Err(err) => {
-                    return Err(anyhow!(err).context("Delete addressbook error"))
+                    return Err(anyhow!(err).context("Create card error"))
                 }
                 SendResult::Io(io) => arg = Some(handle(&mut self.stream, io)?),
             }
@@ -292,7 +292,7 @@ impl<'a> CarddavClient<'a> {
             match list.resume(arg.take()) {
                 SendResult::Ok(ok) => break Ok(ok.body),
                 SendResult::Err(err) => {
-                    return Err(anyhow!(err).context("Delete addressbook error"))
+                    return Err(anyhow!(err).context("List cards error"))
                 }
                 SendResult::Io(io) => arg = Some(handle(&mut self.stream, io)?),
             }
@@ -311,7 +311,7 @@ impl<'a> CarddavClient<'a> {
             match read.resume(arg.take()) {
                 SendResult::Ok(ok) => break Ok(ok.body),
                 SendResult::Err(err) => {
-                    return Err(anyhow!(err).context("Delete addressbook error"))
+                    return Err(anyhow!(err).context("Read card error"))
                 }
                 SendResult::Io(io) => arg = Some(handle(&mut self.stream, io)?),
             }
@@ -326,7 +326,7 @@ impl<'a> CarddavClient<'a> {
             match update.resume(arg.take()) {
                 SendResult::Ok(_) => break Ok(()),
                 SendResult::Err(err) => {
-                    return Err(anyhow!(err).context("Delete addressbook error"))
+                    return Err(anyhow!(err).context("Update card error"))
                 }
                 SendResult::Io(io) => arg = Some(handle(&mut self.stream, io)?),
             }
@@ -345,7 +345,7 @@ impl<'a> CarddavClient<'a> {
             match delete.resume(arg.take()) {
                 SendResult::Ok(_) => break Ok(()),
                 SendResult::Err(err) => {
-                    return Err(anyhow!(err).context("Delete addressbook error"))
+                    return Err(anyhow!(err).context("Delete card error"))
                 }
                 SendResult::Io(io) => arg = Some(handle(&mut self.stream, io)?),
             }


### PR DESCRIPTION
## Summary
- Fix all 6 error context strings in `CarddavClient` to match their actual operations
- `create_addressbook`: "Creat addressbook error" → "Create addressbook error"
- `create_card`: "Delete addressbook error" → "Create card error"
- `list_cards`: "Delete addressbook error" → "List cards error"
- `read_card`: "Delete addressbook error" → "Read card error"
- `update_card`: "Delete addressbook error" → "Update card error"
- `delete_card`: "Delete addressbook error" → "Delete card error"

Fixes #19

<details>
<summary>Context</summary>

I'm setting up a self-hosted PIM stack with Stalwart mail server. I already use himalaya for email and it works great. Now I want contacts and calendar management via CLI too, and found cardamum and calendula in the pimalaya project. I ran CRUD tests (create, list, read, update, delete) for both contacts and calendar items against my Stalwart instance and hit a few issues. Since I had the repos cloned locally I was able to fix them to get everything working.

Heads up: this issue (and PR if attached) was created with the help of Claude Code and hasn't been deeply reviewed on my end. If it's not useful or doesn't fit, feel free to close it — no hard feelings at all. If it looks interesting but needs more thought, ping me and I'll give it a proper review with my own eyes.

</details>