### PR TITLE
feat: support Netease CardDAV groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,7 @@ dependencies = [
  "http",
  "io-addressbook",
  "io-fs",
+ "io-http",
  "io-stream",
  "log",
  "pimalaya-toolbox",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ env_logger = "0.11"
 http = { version = "1", optional = true }
 io-addressbook = { version = "0.0.1", default-features = false }
 io-fs = { version = "0.0.1", default-features = false, features = ["std"], optional = true }
+io-http = "0.0.3"
 io-stream = { version = "0.0.2", default-features = false, features = ["std"], optional = true }
 log = "0.4"
 pimalaya-toolbox = { version = "0.0.2", default-features = false, features = ["config", "prompt", "secret", "stream", "terminal"] }

--- a/src/card/command/create.rs
+++ b/src/card/command/create.rs
@@ -45,7 +45,7 @@ impl CreateCardCommand {
     pub fn execute(self, printer: &mut impl Printer, account: Account) -> Result<()> {
         let mut client = Client::new(&account)?;
 
-        let uid = Card::new_uuid();
+        let uid = Card::new_uuid().to_string();
         let path = temp_dir().join(format!("{uid}.vcf"));
         let tpl = format!(include_str!("./create.vcf"), uid);
         fs::write(&path, tpl)?;
@@ -70,7 +70,7 @@ impl CreateCardCommand {
             .replace('\n', "\r\n");
 
         let card = Card {
-            id: Card::new_uuid().to_string(),
+            id: uid,
             addressbook_id: self.addressbook_id,
             vcard: Card::parse(content).context("cannot parse vCard")?,
         };

--- a/src/card/command/list.rs
+++ b/src/card/command/list.rs
@@ -20,7 +20,11 @@ use anyhow::Result;
 use clap::Parser;
 use pimalaya_toolbox::terminal::printer::Printer;
 
-use crate::{account::Account, card::table::CardsTable, client::Client};
+use crate::{
+    account::Account,
+    card::table::{CardsTable, CardsTableMode},
+    client::Client,
+};
 
 /// List all cards.
 ///
@@ -30,6 +34,10 @@ pub struct ListCardsCommand {
     /// The identifier of the CardDAV addressbook to list vCards from.
     #[arg(name = "ADDRESSBOOK-ID")]
     pub addressbook_id: String,
+
+    /// List contact groups instead of contacts.
+    #[arg(long)]
+    pub groups: bool,
 }
 
 impl ListCardsCommand {
@@ -37,7 +45,12 @@ impl ListCardsCommand {
         let mut client = Client::new(&account)?;
 
         let cards = client.list_cards(self.addressbook_id)?;
-        let table = CardsTable::from(cards);
+        let mode = if self.groups {
+            CardsTableMode::Groups
+        } else {
+            CardsTableMode::Contacts
+        };
+        let table = CardsTable::from(cards).with_mode(mode);
         printer.out(table)
     }
 }

--- a/src/card/command/read.rs
+++ b/src/card/command/read.rs
@@ -16,11 +16,19 @@
 // License along with this program. If not, see
 // <https://www.gnu.org/licenses/>.
 
+use std::fmt;
+
 use anyhow::Result;
 use clap::Parser;
+use io_addressbook::card::Card;
 use pimalaya_toolbox::terminal::printer::Printer;
+use serde::Serialize;
 
-use crate::{account::Account, client::Client};
+use crate::{
+    account::Account,
+    card::utils::{build_group_names_by_cid, contact_group_names},
+    client::Client,
+};
 
 /// Read the content of a card.
 ///
@@ -36,12 +44,60 @@ pub struct ReadCardCommand {
     /// The identifier of the card that should be read.
     #[arg(name = "CARD-ID")]
     pub id: String,
+
+    /// Print the raw vCard only.
+    #[arg(long)]
+    pub raw: bool,
 }
 
 impl ReadCardCommand {
     pub fn execute(self, printer: &mut impl Printer, account: Account) -> Result<()> {
         let mut client = Client::new(&account)?;
-        let card = client.read_card(self.addressbook_id, self.id)?;
-        printer.out(card.to_string().trim_end())
+        let card = client.read_card(&self.addressbook_id, &self.id)?;
+
+        if self.raw {
+            return printer.out(card.to_string().trim_end());
+        }
+
+        let cards = client.list_cards(&self.addressbook_id)?;
+        let group_names_by_cid = build_group_names_by_cid(&cards);
+        let output = ReadCardOutput {
+            id: card.id.clone(),
+            addressbook_id: card.addressbook_id.clone(),
+            groups: contact_group_names(&card, &group_names_by_cid),
+            vcard: card,
+        };
+
+        printer.out(output)
     }
+}
+
+#[derive(Clone, Debug, Serialize)]
+struct ReadCardOutput {
+    id: String,
+    addressbook_id: String,
+    groups: Vec<String>,
+    #[serde(serialize_with = "serialize_card")]
+    vcard: Card,
+}
+
+impl fmt::Display for ReadCardOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let groups = if self.groups.is_empty() {
+            String::from("(none)")
+        } else {
+            self.groups.join(", ")
+        };
+
+        writeln!(f, "Groups: {groups}")?;
+        writeln!(f)?;
+        write!(f, "{}", self.vcard.to_string().trim_end())
+    }
+}
+
+fn serialize_card<S>(card: &Card, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    serializer.serialize_str(card.to_string().trim_end())
 }

--- a/src/card/command/update.rs
+++ b/src/card/command/update.rs
@@ -78,7 +78,6 @@ impl UpdateCardCommand {
             vcard: Card::parse(content).context("cannot parse vCard")?,
         };
 
-        println!("pre update");
         client.update_card(card)?;
 
         printer.out("Card successfully updated")

--- a/src/card/mod.rs
+++ b/src/card/mod.rs
@@ -18,3 +18,4 @@
 
 pub mod command;
 pub mod table;
+pub(crate) mod utils;

--- a/src/card/table.rs
+++ b/src/card/table.rs
@@ -20,10 +20,22 @@ use std::{collections::HashSet, fmt};
 
 use comfy_table::{presets, Cell, ContentArrangement, Row, Table};
 use crossterm::style::Color;
-use io_addressbook::card::{Card, VCardValue};
+use io_addressbook::card::Card;
 use serde::{ser::Serializer, Deserialize, Serialize};
 
 use crate::table::map_color;
+
+use super::utils::{
+    build_group_member_counts, build_group_names_by_cid, contact_group_names, first_property_text,
+    group_cid, group_name, is_group_card,
+};
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum CardsTableMode {
+    #[default]
+    Contacts,
+    Groups,
+}
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
@@ -60,9 +72,15 @@ pub struct CardsTable {
     cards: HashSet<Card>,
     width: Option<u16>,
     config: ListCardsTableConfig,
+    mode: CardsTableMode,
 }
 
 impl CardsTable {
+    pub fn with_mode(mut self, mode: CardsTableMode) -> Self {
+        self.mode = mode;
+        self
+    }
+
     pub fn with_some_width(mut self, width: Option<u16>) -> Self {
         self.width = width;
         self
@@ -82,52 +100,97 @@ impl CardsTable {
         self.config.version_color = color;
         self
     }
+
+    fn visible_cards(&self) -> Vec<Card> {
+        let mut cards = self
+            .cards
+            .iter()
+            .filter(|card| match self.mode {
+                CardsTableMode::Contacts => !is_group_card(card),
+                CardsTableMode::Groups => is_group_card(card),
+            })
+            .cloned()
+            .collect::<Vec<_>>();
+
+        cards.sort_by(|left, right| {
+            let left_name = sort_key_name(left);
+            let right_name = sort_key_name(right);
+            left_name.cmp(&right_name).then(left.id.cmp(&right.id))
+        });
+
+        cards
+    }
 }
 
 impl fmt::Display for CardsTable {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut table = Table::new();
-
-        let props = self.config.properties();
-
-        let mut headers = vec![String::from("ID"), String::from("VERSION")];
-
-        headers.extend_from_slice(&props);
-
         table
             .load_preset(self.config.preset())
-            .set_content_arrangement(ContentArrangement::DynamicFullWidth)
-            .set_header(Row::from(headers))
-            .add_rows(self.cards.iter().map(|card| {
-                let mut row = Row::new();
-                row.max_height(1);
+            .set_content_arrangement(ContentArrangement::DynamicFullWidth);
 
-                row.add_cell(Cell::new(&card.id).fg(self.config.id_color()));
+        match self.mode {
+            CardsTableMode::Contacts => {
+                let props = self.config.properties();
+                let group_names_by_cid = build_group_names_by_cid(&self.cards);
 
-                row.add_cell(match card.vcard.version() {
-                    Some(version) => Cell::new(version).fg(self.config.version_color()),
-                    None => Cell::new(""),
-                });
+                let mut headers = vec![String::from("ID"), String::from("VERSION")];
+                headers.extend_from_slice(&props);
+                headers.push(String::from("GROUPS"));
 
-                for prop in &props {
-                    let mut value = "";
+                table.set_header(Row::from(headers)).add_rows(
+                    self.visible_cards().into_iter().map(|card| {
+                        let mut row = Row::new();
+                        row.max_height(1);
 
-                    if let Ok(prop) = prop.as_bytes().try_into() {
-                        if let Some(prop) = card.vcard.property(&prop) {
-                            if let Some(prop) = prop.values.first() {
-                                value = match prop {
-                                    VCardValue::Text(text) => text.as_str(),
-                                    _ => "",
-                                }
-                            }
+                        row.add_cell(Cell::new(&card.id).fg(self.config.id_color()));
+                        row.add_cell(version_cell(&card, self.config.version_color()));
+
+                        for prop in &props {
+                            row.add_cell(Cell::new(
+                                first_property_text(&card, prop).unwrap_or_default(),
+                            ));
                         }
-                    }
 
-                    row.add_cell(Cell::new(value));
-                }
+                        row.add_cell(Cell::new(
+                            contact_group_names(&card, &group_names_by_cid).join(", "),
+                        ));
 
-                row
-            }));
+                        row
+                    }),
+                );
+            }
+            CardsTableMode::Groups => {
+                let member_counts_by_group_cid = build_group_member_counts(&self.cards);
+
+                table
+                    .set_header(Row::from(vec![
+                        String::from("ID"),
+                        String::from("VERSION"),
+                        String::from("GROUP"),
+                        String::from("CID"),
+                        String::from("MEMBERS"),
+                    ]))
+                    .add_rows(self.visible_cards().into_iter().map(|card| {
+                        let group_cid = group_cid(&card).unwrap_or_default();
+                        let members = member_counts_by_group_cid
+                            .get(&card.id)
+                            .copied()
+                            .unwrap_or_default();
+
+                        let mut row = Row::new();
+                        row.max_height(1);
+
+                        row.add_cell(Cell::new(&card.id).fg(self.config.id_color()));
+                        row.add_cell(version_cell(&card, self.config.version_color()));
+                        row.add_cell(Cell::new(group_name(&card)));
+                        row.add_cell(Cell::new(group_cid));
+                        row.add_cell(Cell::new(members));
+
+                        row
+                    }));
+            }
+        }
 
         if let Some(width) = self.width {
             table.set_width(width);
@@ -145,7 +208,7 @@ impl Serialize for CardsTable {
     where
         S: Serializer,
     {
-        self.cards.serialize(serializer)
+        self.visible_cards().serialize(serializer)
     }
 }
 
@@ -155,6 +218,77 @@ impl From<HashSet<Card>> for CardsTable {
             cards,
             width: Default::default(),
             config: Default::default(),
+            mode: Default::default(),
         }
+    }
+}
+
+fn version_cell(card: &Card, color: comfy_table::Color) -> Cell {
+    match card.vcard.version() {
+        Some(version) => Cell::new(version).fg(color),
+        None => Cell::new(""),
+    }
+}
+
+fn sort_key_name(card: &Card) -> String {
+    group_name(card)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn parse_card(id: &str, addressbook_id: &str, content: &str) -> Card {
+        Card {
+            id: id.to_string(),
+            addressbook_id: addressbook_id.to_string(),
+            vcard: Card::parse(content).unwrap(),
+        }
+    }
+
+    #[test]
+    fn contacts_mode_hides_group_cards_and_shows_group_names() {
+        let contact = parse_card(
+            "123",
+            "contacts",
+            "BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Alice\r\nEMAIL:alice@example.com\r\nGrouping:42\r\nEND:VCARD\r\n",
+        );
+        let group = parse_card(
+            "MacGroup-42",
+            "contacts",
+            "BEGIN:VCARD\r\nVERSION:3.0\r\nN:导师组\r\nUID:MacGroup-42\r\nCID:42\r\nX-TYPE:GROUP\r\nX-ADDRESSBOOKSERVER-KIND:group\r\nEND:VCARD\r\n",
+        );
+
+        let table = CardsTable::from(HashSet::from([contact, group]));
+        let rendered = table.to_string();
+
+        assert!(rendered.contains("Alice"));
+        assert!(rendered.contains("导师组"));
+        assert!(!rendered.contains("MacGroup-42"));
+    }
+
+    #[test]
+    fn groups_mode_lists_groups_with_member_count() {
+        let contact = parse_card(
+            "123",
+            "contacts",
+            "BEGIN:VCARD\r\nVERSION:3.0\r\nFN:Alice\r\nGrouping:42\r\nEND:VCARD\r\n",
+        );
+        let group = parse_card(
+            "MacGroup-42",
+            "contacts",
+            "BEGIN:VCARD\r\nVERSION:3.0\r\nN:导师组\r\nUID:MacGroup-42\r\nCID:42\r\nX-TYPE:GROUP\r\nX-ADDRESSBOOKSERVER-KIND:group\r\nEND:VCARD\r\n",
+        );
+
+        let cards = HashSet::from([contact, group]);
+        let table = CardsTable::from(cards.clone()).with_mode(CardsTableMode::Groups);
+        let rendered = table.to_string();
+
+        assert!(rendered.contains("导师组"));
+        assert!(!rendered.contains("Alice"));
+        assert_eq!(
+            build_group_member_counts(&cards).get("MacGroup-42"),
+            Some(&1)
+        );
     }
 }

--- a/src/card/utils.rs
+++ b/src/card/utils.rs
@@ -1,0 +1,134 @@
+use std::collections::{HashMap, HashSet};
+
+use io_addressbook::card::{Card, VCardValue};
+
+pub(crate) fn is_group_card(card: &Card) -> bool {
+    property_texts(card, "X-ADDRESSBOOKSERVER-KIND")
+        .into_iter()
+        .any(|value| value.eq_ignore_ascii_case("group"))
+        || property_texts(card, "X-TYPE")
+            .into_iter()
+            .any(|value| value.eq_ignore_ascii_case("group"))
+        || property_texts(card, "KIND")
+            .into_iter()
+            .any(|value| value.eq_ignore_ascii_case("group"))
+        || card
+            .vcard
+            .uid()
+            .is_some_and(|uid| uid.starts_with("MacGroup-"))
+}
+
+pub(crate) fn first_property_text(card: &Card, name: &str) -> Option<String> {
+    property_texts(card, name).into_iter().next()
+}
+
+pub(crate) fn property_texts(card: &Card, name: &str) -> Vec<String> {
+    card.entries()
+        .filter(|entry| entry.name.as_str().eq_ignore_ascii_case(name))
+        .flat_map(|entry| entry.values.iter())
+        .filter_map(|value| match value {
+            VCardValue::Text(text) if !text.is_empty() => Some(text.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+pub(crate) fn group_name(card: &Card) -> String {
+    first_property_text(card, "FN")
+        .or_else(|| first_property_text(card, "N"))
+        .unwrap_or_else(|| card.id.clone())
+}
+
+pub(crate) fn group_cid(card: &Card) -> Option<String> {
+    first_property_text(card, "CID").or_else(|| {
+        card.vcard
+            .uid()
+            .and_then(|uid| uid.strip_prefix("MacGroup-"))
+            .map(str::to_owned)
+    })
+}
+
+pub(crate) fn group_lookup_keys(card: &Card) -> Vec<String> {
+    let mut keys = Vec::new();
+
+    keys.push(card.id.clone());
+
+    if let Some(id) = card.id.strip_prefix("MacGroup-") {
+        keys.push(id.to_owned());
+    }
+
+    if let Some(uid) = card.vcard.uid() {
+        keys.push(uid.to_owned());
+
+        if let Some(id) = uid.strip_prefix("MacGroup-") {
+            keys.push(id.to_owned());
+        }
+    }
+
+    if let Some(cid) = group_cid(card) {
+        keys.push(cid);
+    }
+
+    keys.sort();
+    keys.dedup();
+    keys
+}
+
+pub(crate) fn build_group_names_by_cid(cards: &HashSet<Card>) -> HashMap<String, String> {
+    let mut names = HashMap::new();
+
+    for card in cards.iter().filter(|card| is_group_card(card)) {
+        let name = group_name(card);
+
+        for key in group_lookup_keys(card) {
+            names.insert(key, name.clone());
+        }
+    }
+
+    names
+}
+
+pub(crate) fn build_group_member_counts(cards: &HashSet<Card>) -> HashMap<String, usize> {
+    let mut counts_by_grouping = HashMap::new();
+
+    for card in cards.iter().filter(|card| !is_group_card(card)) {
+        let groupings = property_texts(card, "Grouping");
+
+        for grouping in groupings {
+            *counts_by_grouping.entry(grouping).or_insert(0) += 1;
+        }
+    }
+
+    let mut counts = HashMap::new();
+
+    for card in cards.iter().filter(|card| is_group_card(card)) {
+        let mut total = 0usize;
+
+        for key in group_lookup_keys(card) {
+            total += counts_by_grouping.get(&key).copied().unwrap_or_default();
+        }
+
+        counts.insert(card.id.clone(), total);
+    }
+
+    counts
+}
+
+pub(crate) fn contact_group_names(
+    card: &Card,
+    group_names_by_cid: &HashMap<String, String>,
+) -> Vec<String> {
+    let mut names = property_texts(card, "Grouping")
+        .into_iter()
+        .map(|grouping| {
+            group_names_by_cid
+                .get(&grouping)
+                .cloned()
+                .unwrap_or(grouping)
+        })
+        .collect::<Vec<_>>();
+
+    names.sort();
+    names.dedup();
+    names
+}

--- a/src/carddav/client.rs
+++ b/src/carddav/client.rs
@@ -16,14 +16,20 @@
 // License along with this program. If not, see
 // <https://www.gnu.org/licenses/>.
 
-use std::{borrow::Cow, collections::HashSet};
+use std::{
+    borrow::Cow,
+    collections::HashSet,
+    fmt::Write as _,
+    time::{SystemTime, UNIX_EPOCH},
+};
 
-use anyhow::{anyhow, Result};
-use http::Uri;
+use anyhow::{anyhow, Context, Result};
+use http::{StatusCode, Uri};
+use io_http::v1_1::coroutines::send::{SendHttp, SendHttpResult};
 
 use io_addressbook::{
     addressbook::Addressbook,
-    card::Card,
+    card::{Card, VCardValue},
     carddav::{
         coroutines::{
             addressbook_home_set::AddressbookHomeSet,
@@ -36,18 +42,39 @@ use io_addressbook::{
             list_addressbooks::ListAddressbooks,
             list_cards::ListCards,
             read_card::ReadCard,
-            send::SendResult,
+            send::{Send, SendError, SendResult},
             update_addressbook::UpdateAddressbook,
             update_card::UpdateCard,
             well_known::{WellKnown, WellKnownResult},
         },
-        request::set_uri_path,
+        request::{push_uri_path, set_uri_path, Request},
+        response::{Multistatus, PropstatResponse, Value},
     },
 };
 use io_stream::runtimes::std::handle;
+use log::{debug, trace};
 use pimalaya_toolbox::stream::Stream;
+use serde::Deserialize;
 
 use super::config::CarddavConfig;
+
+const LIST_CARDS_PROPFIND_BODY: &str = r#"<?xml version="1.0" encoding="utf-8" ?>
+<propfind xmlns="DAV:">
+  <prop>
+    <getetag />
+  </prop>
+</propfind>
+"#;
+
+const READ_CARD_PROPFIND_BODY: &str = r#"<?xml version="1.0" encoding="utf-8" ?>
+<propfind xmlns="DAV:" xmlns:C="urn:ietf:params:xml:ns:carddav">
+  <prop>
+    <C:address-data />
+  </prop>
+</propfind>
+"#;
+
+const MULTIGET_CARDS_REPORT_CHUNK_SIZE: usize = 500;
 
 #[derive(Debug)]
 pub struct CarddavClient<'a> {
@@ -213,6 +240,445 @@ impl<'a> CarddavClient<'a> {
         Self::from_home_uri(config, stream, Cow::Owned(uri))
     }
 
+    fn is_netease_contacts(&self) -> bool {
+        self.config.uri.host() == Some("contacts.163.com")
+    }
+
+    fn next_netease_card_id() -> String {
+        let millis = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis();
+        millis.to_string()
+    }
+
+    fn netease_card_text_values(card: &Card, name: &str) -> Vec<String> {
+        card.entries()
+            .filter(|entry| entry.name.as_str().eq_ignore_ascii_case(name))
+            .flat_map(|entry| entry.values.iter())
+            .filter_map(|value| match value {
+                VCardValue::Text(text) if !text.is_empty() => Some(text.clone()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn is_netease_group_card(card: &Card) -> bool {
+        Self::netease_card_text_values(card, "X-ADDRESSBOOKSERVER-KIND")
+            .into_iter()
+            .any(|value| value.eq_ignore_ascii_case("group"))
+            || Self::netease_card_text_values(card, "X-TYPE")
+                .into_iter()
+                .any(|value| value.eq_ignore_ascii_case("group"))
+            || Self::netease_card_text_values(card, "KIND")
+                .into_iter()
+                .any(|value| value.eq_ignore_ascii_case("group"))
+            || card
+                .vcard
+                .uid()
+                .is_some_and(|uid| uid.starts_with("MacGroup-"))
+    }
+
+    fn extract_netease_group_cid(card: &Card) -> Option<String> {
+        Self::netease_card_text_values(card, "CID")
+            .into_iter()
+            .next()
+            .or_else(|| {
+                card.vcard
+                    .uid()
+                    .and_then(|uid| uid.strip_prefix("MacGroup-"))
+                    .map(str::to_owned)
+            })
+    }
+
+    fn normalize_netease_vcard(content: String, id: &str) -> String {
+        let mut lines = content
+            .replace("\r\n", "\n")
+            .replace('\r', "\n")
+            .split('\n')
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+
+        let mut has_uid = false;
+        let mut has_cid = false;
+
+        for line in &mut lines {
+            if line
+                .split_once(':')
+                .map(|(key, _)| key.eq_ignore_ascii_case("UID"))
+                == Some(true)
+            {
+                *line = format!("UID:{id}");
+                has_uid = true;
+                continue;
+            }
+
+            if line
+                .split_once(':')
+                .map(|(key, _)| key.eq_ignore_ascii_case("CID"))
+                == Some(true)
+            {
+                *line = format!("CID:{id}");
+                has_cid = true;
+            }
+        }
+
+        let end_idx = lines
+            .iter()
+            .position(|line| line.eq_ignore_ascii_case("END:VCARD"))
+            .unwrap_or(lines.len());
+
+        if !has_uid {
+            lines.insert(end_idx, format!("UID:{id}"));
+        }
+
+        if !has_cid {
+            let end_idx = lines
+                .iter()
+                .position(|line| line.eq_ignore_ascii_case("END:VCARD"))
+                .unwrap_or(lines.len());
+            lines.insert(end_idx, format!("CID:{id}"));
+        }
+
+        if !lines
+            .iter()
+            .any(|line| line.eq_ignore_ascii_case("END:VCARD"))
+        {
+            lines.push("END:VCARD".to_string());
+        }
+
+        lines.join("\r\n")
+    }
+
+    fn normalize_netease_group_vcard(content: String, cid: &str) -> String {
+        let group_id = format!("MacGroup-{cid}");
+        let mut lines = content
+            .replace("\r\n", "\n")
+            .replace('\r', "\n")
+            .split('\n')
+            .map(str::to_owned)
+            .collect::<Vec<_>>();
+
+        let mut has_uid = false;
+        let mut has_cid = false;
+        let mut has_x_type = false;
+        let mut has_kind = false;
+
+        for line in &mut lines {
+            if line
+                .split_once(':')
+                .map(|(key, _)| key.eq_ignore_ascii_case("UID"))
+                == Some(true)
+            {
+                *line = format!("UID:{group_id}");
+                has_uid = true;
+                continue;
+            }
+
+            if line
+                .split_once(':')
+                .map(|(key, _)| key.eq_ignore_ascii_case("CID"))
+                == Some(true)
+            {
+                *line = format!("CID:{cid}");
+                has_cid = true;
+                continue;
+            }
+
+            if line.split_once(':').map(|(key, value)| {
+                key.eq_ignore_ascii_case("X-TYPE") && value.eq_ignore_ascii_case("GROUP")
+            }) == Some(true)
+            {
+                *line = "X-TYPE:GROUP".to_string();
+                has_x_type = true;
+                continue;
+            }
+
+            if line.split_once(':').map(|(key, value)| {
+                key.eq_ignore_ascii_case("X-ADDRESSBOOKSERVER-KIND")
+                    && value.eq_ignore_ascii_case("group")
+            }) == Some(true)
+            {
+                *line = "X-ADDRESSBOOKSERVER-KIND:group".to_string();
+                has_kind = true;
+            }
+        }
+
+        let mut end_idx = lines
+            .iter()
+            .position(|line| line.eq_ignore_ascii_case("END:VCARD"))
+            .unwrap_or(lines.len());
+
+        if !has_uid {
+            lines.insert(end_idx, format!("UID:{group_id}"));
+            end_idx += 1;
+        }
+
+        if !has_cid {
+            lines.insert(end_idx, format!("CID:{cid}"));
+            end_idx += 1;
+        }
+
+        if !has_x_type {
+            lines.insert(end_idx, "X-TYPE:GROUP".to_string());
+            end_idx += 1;
+        }
+
+        if !has_kind {
+            lines.insert(end_idx, "X-ADDRESSBOOKSERVER-KIND:group".to_string());
+        }
+
+        if !lines
+            .iter()
+            .any(|line| line.eq_ignore_ascii_case("END:VCARD"))
+        {
+            lines.push("END:VCARD".to_string());
+        }
+
+        lines.join("\r\n")
+    }
+
+    fn normalize_card_for_upload(&self, card: Card) -> Result<Card> {
+        if !self.is_netease_contacts() {
+            return Ok(card);
+        }
+
+        if Self::is_netease_group_card(&card) {
+            let cid =
+                Self::extract_netease_group_cid(&card).unwrap_or_else(Self::next_netease_card_id);
+            let id = format!("MacGroup-{cid}");
+            let content = Self::normalize_netease_group_vcard(card.to_string(), &cid);
+            let vcard = Card::parse(content).context("Parse normalized group vCard")?;
+
+            return Ok(Card {
+                id,
+                addressbook_id: card.addressbook_id,
+                vcard,
+            });
+        }
+
+        let id = if card.id.chars().all(|ch| ch.is_ascii_digit()) {
+            card.id.clone()
+        } else {
+            Self::next_netease_card_id()
+        };
+
+        let content = Self::normalize_netease_vcard(card.to_string(), &id);
+        let vcard = Card::parse(content).context("Parse normalized vCard")?;
+
+        Ok(Card {
+            id,
+            addressbook_id: card.addressbook_id,
+            vcard,
+        })
+    }
+
+    fn list_card_ids_via_propfind(
+        &mut self,
+        addressbook_id: impl AsRef<str>,
+    ) -> Result<Vec<String>> {
+        let addressbook_id = addressbook_id.as_ref();
+        let request = Request::propfind(&self.config, format!("{addressbook_id}/"))
+            .content_type_xml()
+            .depth(1);
+        let mut send = Send::<Multistatus<GetetagProp>>::new(
+            request,
+            LIST_CARDS_PROPFIND_BODY.as_bytes().to_vec(),
+        );
+        let mut arg = None;
+
+        let ok = loop {
+            match send.resume(arg.take()) {
+                SendResult::Ok(ok) => break ok,
+                SendResult::Err(err) => {
+                    return Err(anyhow!(err).context("List cards via PROPFIND error"))
+                }
+                SendResult::Io(io) => arg = Some(handle(&mut self.stream, io)?),
+            }
+        };
+
+        let mut ids = HashSet::new();
+
+        if let Some(responses) = ok.body.responses {
+            for response in responses {
+                trace!("process multistatus");
+
+                let Some(propstats) = response.propstats else {
+                    continue;
+                };
+
+                let has_getetag = propstats.into_iter().any(|propstat| {
+                    propstat.status.is_success() && propstat.prop.getetag.is_some()
+                });
+
+                if !has_getetag {
+                    debug!("multistatus propstat response error");
+                    continue;
+                }
+
+                let Some(id) = card_id_from_href(&response.href.value) else {
+                    continue;
+                };
+
+                ids.insert(id.to_string());
+            }
+        }
+
+        Ok(ids.into_iter().collect())
+    }
+
+    fn card_href(&self, addressbook_id: &str, card_id: &str) -> String {
+        push_uri_path(
+            self.config.uri.clone().into_owned(),
+            format!("/{addressbook_id}/{card_id}.vcf"),
+        )
+        .path()
+        .to_string()
+    }
+
+    fn read_cards_via_multiget(
+        &mut self,
+        addressbook_id: impl AsRef<str>,
+        card_ids: &[String],
+    ) -> Result<HashSet<Card>> {
+        let addressbook_id = addressbook_id.as_ref();
+        let mut cards = HashSet::new();
+
+        for chunk in card_ids.chunks(MULTIGET_CARDS_REPORT_CHUNK_SIZE) {
+            let hrefs = chunk
+                .iter()
+                .map(|card_id| self.card_href(addressbook_id, card_id))
+                .collect::<Vec<_>>();
+            let request = Request::report(&self.config, format!("{addressbook_id}/"))
+                .content_type_xml()
+                .depth(1);
+            let mut send = Send::<Multistatus<AddressDataProp>>::new(
+                request,
+                build_addressbook_multiget_body(hrefs.iter().map(String::as_str)).into_bytes(),
+            );
+            let mut arg = None;
+
+            let ok = loop {
+                match send.resume(arg.take()) {
+                    SendResult::Ok(ok) => break ok,
+                    SendResult::Err(err) => {
+                        return Err(
+                            anyhow!(err).context("List cards via addressbook-multiget error")
+                        )
+                    }
+                    SendResult::Io(io) => arg = Some(handle(&mut self.stream, io)?),
+                }
+            };
+
+            if let Some(responses) = ok.body.responses {
+                for response in responses {
+                    trace!("process multistatus");
+
+                    let Some(card) = parse_address_data_card(response, addressbook_id) else {
+                        continue;
+                    };
+
+                    cards.insert(card);
+                }
+            }
+        }
+
+        Ok(cards)
+    }
+
+    fn read_card_via_propfind(
+        &mut self,
+        addressbook_id: impl AsRef<str>,
+        card_id: impl AsRef<str>,
+    ) -> Result<Card> {
+        let addressbook_id = addressbook_id.as_ref();
+        let card_id = card_id.as_ref();
+        let request = Request::propfind(&self.config, format!("{addressbook_id}/{card_id}.vcf"))
+            .content_type_xml()
+            .depth(0);
+        let mut send = Send::<Multistatus<AddressDataProp>>::new(
+            request,
+            READ_CARD_PROPFIND_BODY.as_bytes().to_vec(),
+        );
+        let mut arg = None;
+
+        let ok = loop {
+            match send.resume(arg.take()) {
+                SendResult::Ok(ok) => break ok,
+                SendResult::Err(err) => {
+                    return Err(anyhow!(err).context("Read card via PROPFIND error"))
+                }
+                SendResult::Io(io) => arg = Some(handle(&mut self.stream, io)?),
+            }
+        };
+
+        let Some(responses) = ok.body.responses else {
+            return Err(anyhow!("Missing multistatus response"));
+        };
+
+        for response in responses {
+            if let Some(status) = response.status {
+                if !status.is_success() {
+                    continue;
+                }
+            }
+
+            let Some(propstats) = response.propstats else {
+                continue;
+            };
+
+            for propstat in propstats {
+                if !propstat.status.is_success() {
+                    continue;
+                }
+
+                let Some(content) = propstat.prop.address_data else {
+                    continue;
+                };
+
+                let vcard = Card::parse(content.value).context("Parse CardDAV address-data")?;
+                return Ok(Card {
+                    id: card_id.to_string(),
+                    addressbook_id: addressbook_id.to_string(),
+                    vcard,
+                });
+            }
+        }
+
+        Err(anyhow!("Missing CardDAV address-data"))
+    }
+
+    fn delete_card_raw(
+        &mut self,
+        addressbook_id: impl AsRef<str>,
+        card_id: impl AsRef<str>,
+    ) -> Result<()> {
+        let addressbook_id = addressbook_id.as_ref();
+        let card_id = card_id.as_ref();
+        let path = format!("/{addressbook_id}/{card_id}.vcf");
+        let request = Request::delete(&self.config, path).body(Vec::<u8>::new());
+        let mut send = SendHttp::new(request);
+        let mut arg = None;
+
+        loop {
+            match send.resume(arg.take()) {
+                SendHttpResult::Ok(ok) => {
+                    let status = ok.response.status();
+                    if status.is_success() {
+                        return Ok(());
+                    }
+
+                    let body = String::from_utf8_lossy(ok.response.body()).to_string();
+                    return Err(anyhow!("HTTP response error {status}: {body}"));
+                }
+                SendHttpResult::Err(err) => {
+                    return Err(anyhow!(err).context("Delete card raw HTTP error"))
+                }
+                SendHttpResult::Io(io) => arg = Some(handle(&mut self.stream, io)?),
+            }
+        }
+    }
+
     pub fn create_addressbook(&mut self, addressbook: Addressbook) -> Result<()> {
         let mut create = CreateAddressbook::new(&self.config, addressbook);
         let mut arg = None;
@@ -220,7 +686,9 @@ impl<'a> CarddavClient<'a> {
         loop {
             match create.resume(arg.take()) {
                 SendResult::Ok(_) => break Ok(()),
-                SendResult::Err(err) => return Err(anyhow!(err).context("Create addressbook error")),
+                SendResult::Err(err) => {
+                    return Err(anyhow!(err).context("Create addressbook error"))
+                }
                 SendResult::Io(io) => arg = Some(handle(&mut self.stream, io)?),
             }
         }
@@ -270,30 +738,56 @@ impl<'a> CarddavClient<'a> {
     }
 
     pub fn create_card(&mut self, card: Card) -> Result<()> {
+        let card = self.normalize_card_for_upload(card)?;
         let mut create = CreateCard::new(&self.config, card);
         let mut arg = None;
 
         loop {
             match create.resume(arg.take()) {
                 SendResult::Ok(_) => break Ok(()),
-                SendResult::Err(err) => {
-                    return Err(anyhow!(err).context("Create card error"))
-                }
+                SendResult::Err(err) => return Err(anyhow!(err).context("Create card error")),
                 SendResult::Io(io) => arg = Some(handle(&mut self.stream, io)?),
             }
         }
     }
 
     pub fn list_cards(&mut self, addressbook_id: impl AsRef<str>) -> Result<HashSet<Card>> {
-        let mut list = ListCards::new(&self.config, addressbook_id);
+        let addressbook_id = addressbook_id.as_ref().to_owned();
+        let mut list = ListCards::new(&self.config, &addressbook_id);
         let mut arg = None;
 
         loop {
             match list.resume(arg.take()) {
                 SendResult::Ok(ok) => break Ok(ok.body),
-                SendResult::Err(err) => {
-                    return Err(anyhow!(err).context("List cards error"))
+                SendResult::Err(SendError::Response(StatusCode::NOT_IMPLEMENTED, _))
+                    if self.is_netease_contacts() =>
+                {
+                    let ids = self.list_card_ids_via_propfind(&addressbook_id)?;
+                    break match self.read_cards_via_multiget(&addressbook_id, &ids) {
+                        Ok(cards) => Ok(cards),
+                        Err(err) => {
+                            debug!(
+                                "cannot list cards via addressbook-multiget: {err:#}; falling back to per-card PROPFIND"
+                            );
+
+                            let mut cards = HashSet::new();
+
+                            for id in ids {
+                                match self.read_card_via_propfind(&addressbook_id, &id) {
+                                    Ok(card) => {
+                                        cards.insert(card);
+                                    }
+                                    Err(err) => {
+                                        debug!("cannot read card {id} via PROPFIND: {err:#}");
+                                    }
+                                }
+                            }
+
+                            Ok(cards)
+                        }
+                    };
                 }
+                SendResult::Err(err) => return Err(anyhow!(err).context("List cards error")),
                 SendResult::Io(io) => arg = Some(handle(&mut self.stream, io)?),
             }
         }
@@ -304,30 +798,34 @@ impl<'a> CarddavClient<'a> {
         addressbook_id: impl AsRef<str>,
         card_id: impl AsRef<str>,
     ) -> Result<Card> {
-        let mut read = ReadCard::new(&self.config, addressbook_id, card_id);
+        let addressbook_id = addressbook_id.as_ref().to_owned();
+        let card_id = card_id.as_ref().to_owned();
+        let mut read = ReadCard::new(&self.config, &addressbook_id, &card_id);
         let mut arg = None;
 
         loop {
             match read.resume(arg.take()) {
                 SendResult::Ok(ok) => break Ok(ok.body),
-                SendResult::Err(err) => {
-                    return Err(anyhow!(err).context("Read card error"))
+                SendResult::Err(SendError::Response(StatusCode::NOT_IMPLEMENTED, _))
+                    if self.is_netease_contacts() =>
+                {
+                    break self.read_card_via_propfind(&addressbook_id, &card_id);
                 }
+                SendResult::Err(err) => return Err(anyhow!(err).context("Read card error")),
                 SendResult::Io(io) => arg = Some(handle(&mut self.stream, io)?),
             }
         }
     }
 
     pub fn update_card(&mut self, card: Card) -> Result<()> {
+        let card = self.normalize_card_for_upload(card)?;
         let mut update = UpdateCard::new(&self.config, card);
         let mut arg = None;
 
         loop {
             match update.resume(arg.take()) {
                 SendResult::Ok(_) => break Ok(()),
-                SendResult::Err(err) => {
-                    return Err(anyhow!(err).context("Update card error"))
-                }
+                SendResult::Err(err) => return Err(anyhow!(err).context("Update card error")),
                 SendResult::Io(io) => arg = Some(handle(&mut self.stream, io)?),
             }
         }
@@ -338,17 +836,127 @@ impl<'a> CarddavClient<'a> {
         addressbook_id: impl AsRef<str>,
         card_id: impl AsRef<str>,
     ) -> Result<()> {
+        if self.is_netease_contacts() {
+            return self.delete_card_raw(addressbook_id, card_id);
+        }
+
         let mut delete = DeleteCard::new(&self.config, addressbook_id, card_id);
         let mut arg = None;
 
         loop {
             match delete.resume(arg.take()) {
                 SendResult::Ok(_) => break Ok(()),
-                SendResult::Err(err) => {
-                    return Err(anyhow!(err).context("Delete card error"))
-                }
+                SendResult::Err(err) => return Err(anyhow!(err).context("Delete card error")),
                 SendResult::Io(io) => arg = Some(handle(&mut self.stream, io)?),
             }
         }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct GetetagProp {
+    getetag: Option<Value>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct AddressDataProp {
+    address_data: Option<Value>,
+}
+
+fn card_id_from_href(href: &str) -> Option<&str> {
+    let href = href.trim_end_matches('/');
+    if !href.to_ascii_lowercase().ends_with(".vcf") {
+        return None;
+    }
+
+    let mut parts = href.rsplit(['.', '/']);
+    parts.next();
+    parts.next()
+}
+
+fn build_addressbook_multiget_body<'a>(hrefs: impl IntoIterator<Item = &'a str>) -> String {
+    let mut body = String::from(
+        r#"<?xml version="1.0" encoding="utf-8" ?>
+<C:addressbook-multiget xmlns="DAV:" xmlns:C="urn:ietf:params:xml:ns:carddav">
+  <prop>
+    <C:address-data />
+  </prop>
+"#,
+    );
+
+    for href in hrefs {
+        let _ = writeln!(body, "  <href>{href}</href>");
+    }
+
+    body.push_str("</C:addressbook-multiget>\n");
+    body
+}
+
+fn parse_address_data_card(
+    response: PropstatResponse<AddressDataProp>,
+    addressbook_id: &str,
+) -> Option<Card> {
+    if let Some(status) = response.status {
+        if !status.is_success() {
+            debug!("multistatus response error");
+            return None;
+        }
+    }
+
+    let Some(propstats) = response.propstats else {
+        return None;
+    };
+
+    let id = card_id_from_href(&response.href.value)?.to_string();
+
+    for propstat in propstats {
+        if !propstat.status.is_success() {
+            debug!("multistatus propstat error");
+            continue;
+        }
+
+        let Some(content) = propstat.prop.address_data else {
+            continue;
+        };
+
+        let Ok(vcard) = Card::parse(content.value) else {
+            continue;
+        };
+
+        return Some(Card {
+            id,
+            addressbook_id: addressbook_id.to_string(),
+            vcard,
+        });
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extracts_card_id_from_href() {
+        assert_eq!(
+            card_id_from_href("/carddav/hash/contacts/1773979575174.vcf"),
+            Some("1773979575174")
+        );
+        assert_eq!(card_id_from_href("/carddav/hash/contacts/"), None);
+    }
+
+    #[test]
+    fn builds_multiget_body_with_all_hrefs() {
+        let body = build_addressbook_multiget_body([
+            "/carddav/hash/contacts/1.vcf",
+            "/carddav/hash/contacts/2.vcf",
+        ]);
+
+        assert!(body.contains("<C:addressbook-multiget"));
+        assert!(body.contains("<href>/carddav/hash/contacts/1.vcf</href>"));
+        assert!(body.contains("<href>/carddav/hash/contacts/2.vcf</href>"));
     }
 }


### PR DESCRIPTION
## Summary
- add Netease/163-specific CardDAV fallbacks for list/read/delete operations and normalize uploaded contact/group vCards
- expose group-aware card listing and reading in the CLI, including a --groups view and group membership output
- add helper tests for group table rendering and CardDAV multiget request handling

## Testing
- cargo +1.93.0 test --lib --bins
- cargo fmt --check