### PR TITLE
build(nix): fix development shell environment

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,13 @@
-{
-  pimalaya ? import (fetchTarball "https://github.com/pimalaya/nix/archive/master.tar.gz"),
-  ...
-}:
+{ pkgs ? import <nixpkgs> {} }:
 
-pimalaya.mkShell {
-  extraBuildInputs = "nixd,nixfmt-rfc-style,dbus,openssl";
+pkgs.mkShell {
+  nativeBuildInputs = [
+    pkgs.pkg-config
+  ];
+  buildInputs = [
+    pkgs.cargo
+    pkgs.rustc
+    pkgs.dbus
+    pkgs.openssl
+  ];
 }


### PR DESCRIPTION
This PR resolves a build environment issue where the `nix-shell` development environment failed to spawn due to `extraBuildInputs` being called with an unexpected parameter in the upstream `pimalaya/nix` flake.

The implementation was changed to a standard `pkgs.mkShell` declaration with explicit `cargo`, `rustc`, `pkg-config`, `openssl`, and `dbus` inputs, making the environment completely independent of any upstream `mkShell` signature changes.