### PR TITLE
fix(card): output structured JSON for read, create, and update

### DIFF
--- a/src/card/command/create.rs
+++ b/src/card/command/create.rs
@@ -25,7 +25,7 @@ use std::{
 use anyhow::{bail, Context, Result};
 use clap::Parser;
 use io_addressbook::card::Card;
-use pimalaya_toolbox::terminal::printer::Printer;
+use pimalaya_toolbox::terminal::printer::{Message, Printer};
 
 use crate::{account::Account, client::Client};
 
@@ -77,6 +77,6 @@ impl CreateCardCommand {
 
         client.create_card(card)?;
 
-        printer.out("Card successfully created")
+        printer.out(Message::new("Card successfully created"))
     }
 }

--- a/src/card/command/read.rs
+++ b/src/card/command/read.rs
@@ -16,9 +16,13 @@
 // License along with this program. If not, see
 // <https://www.gnu.org/licenses/>.
 
+use std::fmt;
+
 use anyhow::Result;
 use clap::Parser;
+use io_addressbook::card::Card;
 use pimalaya_toolbox::terminal::printer::Printer;
+use serde::Serialize;
 
 use crate::{account::Account, client::Client};
 
@@ -42,6 +46,15 @@ impl ReadCardCommand {
     pub fn execute(self, printer: &mut impl Printer, account: Account) -> Result<()> {
         let mut client = Client::new(&account)?;
         let card = client.read_card(self.addressbook_id, self.id)?;
-        printer.out(card.to_string().trim_end())
+        printer.out(ReadCard(card))
+    }
+}
+
+#[derive(Serialize)]
+struct ReadCard(Card);
+
+impl fmt::Display for ReadCard {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0.to_string().trim_end())
     }
 }

--- a/src/card/command/update.rs
+++ b/src/card/command/update.rs
@@ -25,7 +25,7 @@ use std::{
 use anyhow::{bail, Context, Result};
 use clap::Parser;
 use io_addressbook::card::Card;
-use pimalaya_toolbox::terminal::printer::Printer;
+use pimalaya_toolbox::terminal::printer::{Message, Printer};
 
 use crate::{account::Account, client::Client};
 
@@ -81,6 +81,6 @@ impl UpdateCardCommand {
         println!("pre update");
         client.update_card(card)?;
 
-        printer.out("Card successfully updated")
+        printer.out(Message::new("Card successfully updated"))
     }
 }


### PR DESCRIPTION
This PR fixes a bug where running `cardamum cards read <guid> <guid> --json` did not return a structured JSON object, but instead printed the raw vCard string as a JSON string literal.

### Changes:
1. Added a `ReadCard` wrapper struct around `io_addressbook::card::Card` that implements both `fmt::Display` (for plain text) and `serde::Serialize` (for `--json` mode). This allows the printer to correctly output the structured JSON object rather than a raw string.
2. Wrapped success messages in `CreateCardCommand` and `UpdateCardCommand` with `Message::new(...)` to be consistent with all other commands so that they output structured JSON `{"message": "..."}` objects under `--json` mode.